### PR TITLE
Require Composer v1

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -59,7 +59,7 @@ ynh_install_composer () {
 
 	curl -sS https://getcomposer.org/installer \
 		| COMPOSER_HOME="$workdir/.composer" \
-		php${phpversion} -- --quiet --install-dir="$workdir" \
+		php${phpversion} -- --quiet --version="1.10.16" --install-dir="$workdir" \
 		|| ynh_die "Unable to install Composer."
 
 	# update dependencies to create composer.lock


### PR DESCRIPTION
Closes #63.

## Problem
- wikimedia/composer-merge-plugin is currently not compatible with Composer v2
- robloach/component-installer is currently not compatible with Composer v2

## Solution
- Download Composer v1 instead of default v2

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ampache_ynh%20PR64%20(tituspijean)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ampache_ynh%20PR64%20(tituspijean)/)  
