### PR TITLE
Fix sha256sum of source tar.gz in app.src

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://github.com/ampache/ampache/archive/4.4.0.tar.gz
-SOURCE_SUM=f91e0f3cd5c4dd57ed051667358e4e5cf77ec40e394a85cf6a3b92b802419b27
+SOURCE_SUM=8b5bbce6ef7c6bc7b70b3e481e66e4e5be0a4d0a6467bf929f5357f08b473bbb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true


### PR DESCRIPTION
## Problem
- Currently the checksum in the app.src is wrong, hence the install fails

## Solution
- Adds the right checksum

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
