### PR TITLE
Ampache 5.4.0 needs php-intl

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ YNH_PHP_VERSION="8.0"
 # Composer version
 YNH_COMPOSER_VERSION="2.3.5"
 
-pkg_dependencies="libav-tools|ffmpeg php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-simplexml php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-ldap"
+pkg_dependencies="libav-tools|ffmpeg php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-simplexml php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-intl"
 
 #=================================================
 # EXPERIMENTAL HELPERS


### PR DESCRIPTION
Compared to 4.x branch, Ampache 5.4.0 needs PHP Intl extension. It must be added to dependencies.

## Problem

- Upgrade from 4.x.x to 5.4.0 was successfull, but then, Ampache falls to the test page, saying there's an error with PHP Intl extension.

## Solution

- Added php-intl to dependencies.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

Not tested in real conditions, I restored old 4.x, manually installed php8.0-intl, and did the upgrade again (then Ampache was OK).

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
